### PR TITLE
Fixed priority for building documentation with Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,5 +78,5 @@ uninstall:
 	dvips $(notdir $<);
 %.dvi:
 	cd $(dir $@); \
-	TEXINPUTS=":$(CURDIR)/texmf/tex/latex/tuddesign//:" latex $(basename $(notdir $@)).tex; \
-	TEXINPUTS=":$(CURDIR)/texmf/tex/latex/tuddesign//:" latex $(basename $(notdir $@)).tex;
+	TEXINPUTS="$(CURDIR)/texmf/tex/latex/tuddesign//:" latex $(basename $(notdir $@)).tex; \
+	TEXINPUTS="$(CURDIR)/texmf/tex/latex/tuddesign//:" latex $(basename $(notdir $@)).tex;


### PR DESCRIPTION
TEXINPUTS preferred existing installations of tudadesign
now it uses the classes it's building docs for